### PR TITLE
cleared up the package.json and added non-wildcard test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "Return glob applied and flattened version of the given array. This is a fork of flat-glob.",
   "main": "index.js",
   "scripts": {
-    "test": "prova"
-  },
-  "devDependencies": {
-    "prova": "*"
+    "test" : "mocha test.js"
   },
   "keywords": [
     "array",
@@ -19,10 +16,10 @@
     "type": "git"
   },
   "author": "Allan Bogh <ajbogh@allanbogh.com>",
-  "license": "BSD",
+  "license": "BSD-4-Clause",
   "dependencies": {
     "chai": "^3.5.0",
-    "glob": "~3.2.8",
+    "glob": "~7.0.5",
     "underscore": "^1.8.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -10,10 +10,15 @@ it('applies glob and returns a flat array with no duplicates', function (done){
   });
 });
 
-it('runs synchronously optionally', function(){
-  expect(flatGlob.sync(['index.js', '*.js'])).to.deep.equal(['index.js', 'test.js']);
+it('tests without wildcard', function (done){
+  flatGlob(['index.js', 'test.js', 'test.js'], function (error, files) {
+    if (error) return done(error);
+
+    expect(files).to.deep.equal(['index.js', 'test.js']);
+    done();
+  });
 });
 
 it('runs synchronously optionally', function(){
-  expect(flatGlob.sync(['*.js', '*.md', '!README.md'])).to.deep.equal(['index.js', 'test.js']);
+  expect(flatGlob.sync(['index.js', '*.js'])).to.deep.equal(['index.js', 'test.js']);
 });


### PR DESCRIPTION
**CHANGES:**
- dropped prova as a dev dependency in the project's root package.json, since it wasn't being used for testing
- fixed bsd license to be the correct spdx name
- upgraded glob version to latest stable release (uses the minimatch package verson 3.0.2 or higher to avoid a RegExp DoS issue)
- added without-wildcard test
